### PR TITLE
fix(lib): Serve files that contains same name of static dir

### DIFF
--- a/lib/https-pushstate-server.js
+++ b/lib/https-pushstate-server.js
@@ -22,7 +22,7 @@ let pushstateServer = {
 
 		let getPath = function(url, type) {
 			let paramsRemoved = _.first(url.split('?'));
-			let filepath = _.last(paramsRemoved.split(type));
+			let filepath = _.last(paramsRemoved.split(type + '/'));
 			return path.resolve(rootDir + '/' + type + filepath);
 		};
 


### PR DESCRIPTION
Files that contains the same static directory name are served incorrectly.

### **How to reproduce:**

**dirs**:
build
--- fonts
   ----- fonts.css

**prompt**: # https-pushstate-server -r build -p 8000  -d fonts

**error**: ENOENT: no such file or directory, stat '/../build/fonts.css'

 
